### PR TITLE
Fixes FolderService@createFolderRecursive

### DIFF
--- a/src/Drive/FolderService.php
+++ b/src/Drive/FolderService.php
@@ -227,7 +227,7 @@ class FolderService
         $parentFolderId = null;
         $createFolderResponse = null;
         foreach($pathParts as $path) {
-            $buildPath .= $path;
+            $buildPath = $path;
             $folderMeta = $this->requestFolderMetadata($buildPath);
 
             if($folderMeta !== null) {

--- a/src/Drive/FolderService.php
+++ b/src/Drive/FolderService.php
@@ -227,7 +227,7 @@ class FolderService
         $parentFolderId = null;
         $createFolderResponse = null;
         foreach($pathParts as $path) {
-            $buildPath = $path;
+            $buildPath = sprintf('%s/%s', $buildPath, $path);
             $folderMeta = $this->requestFolderMetadata($buildPath);
 
             if($folderMeta !== null) {


### PR DESCRIPTION
Fixes the `.=` from recursively appends $path to $buildPath. Use $parentFolderId instead.