### PR TITLE
Fixes php8.4 deprecated error

### DIFF
--- a/src/ApiConnector.php
+++ b/src/ApiConnector.php
@@ -20,7 +20,7 @@ class ApiConnector
 
 
     public function __construct(
-        string $accessToken = null,
+        ?string $accessToken = null,
         int $requestTimeout = 60,
         bool $verify = true
     )


### PR DESCRIPTION
Fixes php8.4 error

```
PHP Deprecated:  GWSN\Microsoft\ApiConnector::__construct(): Implicitly marking parameter $accessToken as nullable is deprecated, the explicit nullable type must be used instead in ./ApiConnector.php on line 22
```